### PR TITLE
Add folders listing API

### DIFF
--- a/API.md
+++ b/API.md
@@ -1,0 +1,162 @@
+# HomeTube API Reference
+
+This document describes the HTTP endpoints exposed by the HomeTube API server.
+All responses are JSON unless otherwise noted. Many endpoints require a video
+`key` parameter which can be obtained from search results.
+
+## Endpoints
+
+### GET `/appConfig`
+Return the current application configuration.
+
+Response body: `AppConfig`
+
+### POST `/appConfig`
+Update the application configuration. The request body must be a partial
+`AppConfig` object. On success the updated configuration is returned. Validation
+errors are returned as an array when inputs are invalid.
+
+### GET `/search`
+Search videos. When no query parameters are provided all indexed videos are
+returned. Supported parameters:
+
+- `names`: string to search in file path tokens
+- `length`: one of `moment`, `short`, `middle`, `long`, `movie`
+- `size`: one of `sd`, `hd`, `fhd`, `4k`, `8k`
+- `stars`: number 1-5
+- `tags`: comma separated tags
+
+Response body: array of `VideoDocument`.
+
+### GET `/details`
+Get metadata and properties for a single video.
+Required query parameter: `key`.
+
+Response body: `VideoDetails`.
+
+### POST `/properties`
+Update stars or tags of a video.
+Query parameter `key` must be specified and request body should contain any of
+`stars` or `tags` fields. The updated properties are returned.
+
+### POST `/rename`
+Rename a file. Requires `key` and `name` query parameters.
+The response returns the updated `VideoValues` of the renamed file.
+
+### POST `/convert`
+Enqueue conversion job. Requires `key` and `type=mp4` parameters.
+Returns `{ status: 'queued' | 'processing' | 'available' }` indicating the
+current conversion state.
+
+### DELETE `/convert`
+Remove a converted file. Requires `key` and `type=mp4` parameters.
+Returns `{ status: 'unavailable' | 'queued' | 'processing' | 'available' }`.
+
+### GET `/video`
+Download the video file. When an MP4 file has been converted it will be served
+instead of the original file. Requires `key` parameter.
+The response body is a static file stream.
+
+### GET `/thumbnails`
+Return a thumbnails image. Requires `key` and `minute` parameters where `minute`
+represents the start minute of the thumbnails. The response is a static JPEG
+file with cache header.
+
+### GET `/snapshot`
+Retrieve a snapshot image. Requires `key` parameter. If no snapshot exists a
+`no-snapshot.png` file is returned.
+
+### POST `/snapshot`
+Update the snapshot image for a video. Requires `key` parameter and body
+`{ dataURL: string }` containing a base64 encoded PNG image. Returns `true` on
+success.
+
+### GET `/allTags`
+Return all tags with counts.
+
+### GET `/serverStatus`
+Return status of workers and storages.
+
+Response body: `ServerStatus`.
+
+### GET `/folders`
+List enabled storage folders recursively. `.home-tube` directories are
+ignored.
+
+Response body: array of `Folder` objects.
+
+---
+
+# HomeTube API リファレンス (日本語)
+
+このドキュメントでは HomeTube API サーバーが公開している HTTP エンドポイントを説明します。
+レスポンスは特別な記載がない限り JSON を返します。多くのエンドポイントでは検索結果から取得できる `key` パラメータが必要です。
+
+## エンドポイント
+
+### GET `/appConfig`
+現在のアプリケーション設定を返します。
+
+レスポンスボディ: `AppConfig`
+
+### POST `/appConfig`
+アプリケーション設定を更新します。リクエストボディには部分的な `AppConfig` オブジェクトを指定します。成功すると更新された設定を返します。入力が不正な場合はバリデーションエラーが配列で返されます。
+
+### GET `/search`
+動画を検索します。クエリパラメータを指定しない場合、すべての動画が返されます。利用可能なパラメータ:
+
+- `names`: パスのトークンに対して検索する文字列
+- `length`: `moment`, `short`, `middle`, `long`, `movie` のいずれか
+- `size`: `sd`, `hd`, `fhd`, `4k`, `8k` のいずれか
+- `stars`: 1-5 の数字
+- `tags`: カンマ区切りのタグ
+
+レスポンスボディ: `VideoDocument` の配列
+
+### GET `/details`
+単一の動画のメタデータとプロパティを取得します。
+必須クエリパラメータ: `key`
+
+レスポンスボディ: `VideoDetails`
+
+### POST `/properties`
+動画の star やタグを更新します。
+`key` クエリパラメータを指定し、リクエストボディに `stars` または `tags` を含めます。更新後のプロパティが返されます。
+
+### POST `/rename`
+ファイル名を変更します。`key` と `name` クエリパラメータが必要です。
+レスポンスとして変更後の `VideoValues` が返されます。
+
+### POST `/convert`
+変換ジョブを登録します。`key` と `type=mp4` が必要です。
+`{ status: 'queued' | 'processing' | 'available' }` を返し、現在の変換状態を示します。
+
+### DELETE `/convert`
+変換済みファイルを削除します。`key` と `type=mp4` が必要です。
+`{ status: 'unavailable' | 'queued' | 'processing' | 'available' }` を返します。
+
+### GET `/video`
+動画ファイルをダウンロードします。MP4 に変換済みの場合はそちらが提供されます。
+`key` パラメータが必要です。レスポンスボディは静的ファイルストリームです。
+
+### GET `/thumbnails`
+サムネイル画像を返します。`key` と `minute` パラメータが必要で、`minute` はサムネイルの開始分を表します。レスポンスはキャッシュヘッダ付きの JPEG 画像です。
+
+### GET `/snapshot`
+スナップショット画像を取得します。`key` パラメータが必要です。スナップショットが存在しない場合は `no-snapshot.png` が返されます。
+
+### POST `/snapshot`
+動画のスナップショットを更新します。`key` パラメータと、base64 でエンコードされた PNG 画像を含む `{ dataURL: string }` をボディに指定します。成功すると `true` を返します。
+
+### GET `/allTags`
+タグの一覧とそれぞれの件数を返します。
+
+### GET `/serverStatus`
+ワーカーとストレージの状態を返します。
+
+レスポンスボディ: `ServerStatus`
+
+### GET `/folders`
+有効なストレージフォルダを再帰的に一覧します。`.home-tube` ディレクトリは除外されます。
+
+レスポンスボディ: `Folder` の配列

--- a/src/handlers/FoldersHandler.test.ts
+++ b/src/handlers/FoldersHandler.test.ts
@@ -1,0 +1,17 @@
+import { RequestContext } from '../types';
+import { listFolders } from '../utils/FolderUtils';
+import { foldersHandler } from './FoldersHandler';
+
+describe('foldersHandler', () => {
+    it('returns folders of enabled storages', () => {
+        const appConfig = {
+            storages: [
+                { path: 'test/storage2', enabled: true },
+                { path: 'test/storage1', enabled: false },
+            ],
+        };
+        const context = { appConfig } as RequestContext;
+        const response = foldersHandler.get(context);
+        expect(response.body).toStrictEqual([listFolders('test/storage2')]);
+    });
+});

--- a/src/handlers/FoldersHandler.ts
+++ b/src/handlers/FoldersHandler.ts
@@ -1,0 +1,12 @@
+import { RequestHandler, RequestMethod } from '../types';
+import { listFolders } from '../utils/FolderUtils';
+
+export const foldersHandler: RequestHandler & { get: RequestMethod } = {
+    path: '/folders',
+    get: ({ appConfig }) => {
+        const result = appConfig.storages
+            .filter((s) => s.enabled)
+            .map((s) => listFolders(s.path));
+        return { body: result };
+    },
+};

--- a/src/handlers/defaultRequestHandlers.ts
+++ b/src/handlers/defaultRequestHandlers.ts
@@ -5,6 +5,7 @@ import { convertHandler } from './ConvertHandler';
 import { detailsHandler } from './DetailsHandler';
 import { propertiesHandler } from './PropertiesHandler';
 import { renameHandler } from './RenameHandler';
+import { foldersHandler } from './FoldersHandler';
 import { searchHandler } from './SearchHandler';
 import { serverStatusHandler } from './ServerStatusHandler';
 import { snapshotHandler } from './SnapshotHandler';
@@ -23,4 +24,5 @@ export const defaultRequestHandlers: RequestHandler[] = [
     allTagsHandler,
     serverStatusHandler,
     renameHandler,
+    foldersHandler,
 ];

--- a/src/types.ts
+++ b/src/types.ts
@@ -152,3 +152,9 @@ export type SizeTag = {
     tag: string;
     label: string;
 };
+
+export type Folder = {
+    path: string;
+    name: string;
+    folders: Folder[];
+};

--- a/src/utils/FolderUtils.test.ts
+++ b/src/utils/FolderUtils.test.ts
@@ -1,0 +1,35 @@
+import { listFolders } from './FolderUtils';
+
+describe('listFolders', () => {
+    it('returns nested folder structure', () => {
+        const tree = listFolders('test/storage2');
+        expect(tree).toStrictEqual({
+            path: 'test/storage2',
+            name: 'storage2',
+            folders: [
+                {
+                    path: 'test/storage2/a',
+                    name: 'a',
+                    folders: [
+                        {
+                            path: 'test/storage2/a/b',
+                            name: 'b',
+                            folders: [
+                                {
+                                    path: 'test/storage2/a/b/a',
+                                    name: 'a',
+                                    folders: [],
+                                },
+                            ],
+                        },
+                    ],
+                },
+                {
+                    path: 'test/storage2/b',
+                    name: 'b',
+                    folders: [],
+                },
+            ],
+        });
+    });
+});

--- a/src/utils/FolderUtils.ts
+++ b/src/utils/FolderUtils.ts
@@ -1,0 +1,25 @@
+import { readdirSync, Dirent } from 'fs';
+import { basename, join } from 'path';
+import { META_DIR } from '../const';
+import { Folder } from '../types';
+
+export const listFolders = (path: string): Folder => {
+    const name = basename(path);
+    const folders: Folder[] = [];
+    try {
+        const dirents = readdirSync(path, { withFileTypes: true });
+        dirents.forEach((dirent: Dirent) => {
+            if (!dirent.isDirectory()) {
+                return;
+            }
+            if (dirent.name === META_DIR) {
+                return;
+            }
+            const childPath = join(path, dirent.name);
+            folders.push(listFolders(childPath));
+        });
+    } catch {
+        // ignore unreadable directories
+    }
+    return { path, name, folders };
+};


### PR DESCRIPTION
## Summary
- implement folder tree list via `/folders`
- add filesystem utility to build folder trees
- test folder utilities and handler
- expose the handler in defaultRequestHandlers
- define `Folder` type for response structure
- document the new endpoint in API.md

## Testing
- `npm run build`
- `npm test` *(fails: Command failed: which ffmpeg)*

------
https://chatgpt.com/codex/tasks/task_e_68450da94b208330a4184e827bcbb525