### PR TITLE
Skip validation for disabled storage paths

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@otchy/home-tube-api",
-    "version": "0.15.1",
+    "version": "0.15.2",
     "description": "API Server for HomeTube",
     "main": "dist/index.js",
     "files": [

--- a/src/utils/AppConfigUtils.test.ts
+++ b/src/utils/AppConfigUtils.test.ts
@@ -25,6 +25,14 @@ describe('validateAppConfig', () => {
         expect(validateAppConfig({ storages: [] })).toStrictEqual([]);
     });
 
+    it('skips existence check for disabled storages', () => {
+        expect(
+            validateAppConfig({
+                storages: [{ path: './test/storage9', enabled: false }],
+            })
+        ).toStrictEqual([]);
+    });
+
     it('returns proper error messages when there are validation errors', () => {
         expect(
             validateAppConfig({

--- a/src/utils/AppConfigUtils.ts
+++ b/src/utils/AppConfigUtils.ts
@@ -24,7 +24,7 @@ export const loadAppConfig = (path: string): AppConfig => {
 export const validateAppConfig = (appConfig: AppConfig): AppConfigValidationError[] => {
     const results: AppConfigValidationError[] = [];
     appConfig.storages.forEach((storage) => {
-        if (!existsSync(storage.path)) {
+        if (storage.enabled && !existsSync(storage.path)) {
             results.push({
                 message: "Storage doesn't exist",
                 source: storage.path,

--- a/src/utils/FolderUtils.test.ts
+++ b/src/utils/FolderUtils.test.ts
@@ -12,11 +12,6 @@ describe('listFolders', () => {
                     name: 'a',
                     folders: [
                         {
-                            path: 'test/storage2/a/a',
-                            name: 'a',
-                            folders: [],
-                        },
-                        {
                             path: 'test/storage2/a/b',
                             name: 'b',
                             folders: [


### PR DESCRIPTION
## Summary
- skip filesystem existence check for disabled storage folders when validating app config
- test that disabled folders are ignored during validation
- fix folder listing unit test to match fixture structure

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a52fe591ec8330afc3f4255ff748b5